### PR TITLE
Add FastJSON API and User Serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'psych', '< 4'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 
+gem 'fast_jsonapi'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
       warden (~> 1.2.3)
     drb (2.2.1)
     erubi (1.13.0)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-aarch64-linux-musl)
     ffi (1.17.0-arm-linux-gnu)
@@ -303,6 +305,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   debase (= 0.2.5.beta2)
   devise (~> 4.9)
+  fast_jsonapi
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::UsersController < ApplicationController
   def show
-    render json: current_user
+    render json: UserSerializer.new(current_user).serializable_hash
   end
 end

--- a/app/javascript/navbar.tsx
+++ b/app/javascript/navbar.tsx
@@ -2,10 +2,8 @@ import React from "react";
 import { useEffect, useState } from "react";
 
 interface User {
-  id: number;
   email: string;
-  created_at: string;
-  updated_at: string;
+  id: number;
 }
 
 export default function NavBar() {
@@ -14,7 +12,7 @@ export default function NavBar() {
   useEffect(() => {
     fetch("http://localhost:3000/api/v1/user")
       .then((response) => response.json())
-      .then((data) => setCurrentUser(data))
+      .then((data) => setCurrentUser(data.data?.attributes))
       .catch((error) => console.error("Error fetching data:", error));
   }, []);
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,5 @@
+class UserSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :id, :email
+end

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "turbolinks": "^5.2.0"
   },
   "scripts": {
-    "build": "esbuild app/javascript/* --bundle --outdir=app/assets/builds",
-    "watch": "esbuild app/javascript/* --bundle --outdir=app/assets/builds --watch"
+    "build": "esbuild app/javascript/* --bundle --sourcemap --outdir=app/assets/builds",
+    "watch": "esbuild app/javascript/* --bundle --sourcemap --outdir=app/assets/builds --watch"
   },
   "version": "0.1.0",
   "devDependencies": {


### PR DESCRIPTION
This PR adds User serialization via FastJSON API. I didn't want timestamps to be in the response with the current_user and this will help be more intentional with future JSON responses coming from Rails. I chose FastJSON API because it is faster than ActiveModel Serializers. 

Additionally, this PR fixes an error with missing maps in Chrome.